### PR TITLE
Docs for django 1.8

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 Responsive Theme for Django Admin (Django 1.7+)
-==============================================
+===============================================
 
 .. image:: https://pypip.in/download/bootstrap_admin/badge.png
     :target: https://pypi.python.org/pypi/bootstrap_admin/
@@ -41,18 +41,52 @@ Example:
 
 .. code-block:: python
 
-    INSTALLED_APPS = (
-        # ...
-        'bootstrap_admin', # always before django.contrib.admin
-        'django.contrib.admin',      
-        # ...   
-    )
+    INSTALLED_APPS = (  
+        # ...  
+        'bootstrap_admin', # always before django.contrib.admin  
+        'django.contrib.admin',  
+        # ...  
+    )  
 
-    # For Sidebar Menu in Django 1.7 only (List of apps and models) (RECOMMENDED)
+For Sidebar Menu in Django 1.7 only (List of apps and models) (RECOMMENDED):
+
+.. code-block:: python
+
     from django.conf import global_settings
     TEMPLATE_CONTEXT_PROCESSORS = global_settings.TEMPLATE_CONTEXT_PROCESSORS + (
         'django.core.context_processors.request',
     )
+    BOOTSTRAP_ADMIN_SIDEBAR_MENU = True
+
+For Sidebar Menu in Django 1.8 be sure to have the correct `TEMPLATES settings <https://docs.djangoproject.com/en/1.8/ref/templates/upgrading/>`_ with the correct request template processor loaded `'django.template.context_processors.request'` :
+
+.. code-block:: python
+  
+    from django.conf import global_settings
+    TEMPLATES = [
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': [
+                # insert your TEMPLATE_DIRS here
+            ],
+            'APP_DIRS': True,
+            'OPTIONS': {
+                'context_processors': [
+                    # Insert your TEMPLATE_CONTEXT_PROCESSORS here or use this
+                    # list if you haven't customized them:
+                    'django.contrib.auth.context_processors.auth',
+                    'django.template.context_processors.debug',
+                    'django.template.context_processors.i18n',
+                    'django.template.context_processors.media',
+                    'django.template.context_processors.static',
+                    'django.template.context_processors.tz',
+                    'django.contrib.messages.context_processors.messages',
+                    'django.template.context_processors.request'
+                ]
+            },
+        },
+    ]
+
     BOOTSTRAP_ADMIN_SIDEBAR_MENU = True
 
 


### PR DESCRIPTION
Correct way to configure TEMPLATES settings to use django-admin-bootstrap==0.3.6 with Django 1.8