### PR TITLE
changed / division operator into // operator

### DIFF
--- a/bootstrap_admin/templatetags/bootstrap_admin_template_tags.py
+++ b/bootstrap_admin/templatetags/bootstrap_admin_template_tags.py
@@ -171,5 +171,5 @@ def render_menu_app_list(context):
 
 @register.filter()
 def class_for_field_boxes(line):
-    size_column = MAX_LENGTH_BOOTSTRAP_COLUMN / len(line.fields)
+    size_column = MAX_LENGTH_BOOTSTRAP_COLUMN // len(line.fields)
     return 'col-sm-{0}'.format(size_column or 1)  # if '0' replace with 1


### PR DESCRIPTION
Without it in python3 division result changes into float and bootstrap-backed fieldsets are not working correctly (example: col-sm-6.0 is generated instead of col-sm-6)